### PR TITLE
Add FastAPI web interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,11 +61,27 @@ A random test image is selected, and the model predicts the person's identity wi
    python facial_recognition.py
    ```
 
+## Web Deployment using FastAPI
+
+An interactive web interface is provided using **FastAPI**. It allows you to
+upload an image, performs prediction using the trained model and displays the
+result.
+
+To start the web server:
+
+```sh
+pip install fastapi uvicorn[standard] pillow scikit-learn tensorflow matplotlib seaborn
+python fastapi_app.py
+```
+
+Then navigate to `http://localhost:8000` in your browser to try the demo.
+
 ## Future Improvements
 
 - Implement data augmentation for better generalization
 - Experiment with deeper CNN architectures
 - Optimize hyperparameters for improving the accuracy
+- Package the model so the FastAPI app can load pre-trained weights
 
 ## Author
 

--- a/fastapi_app.py
+++ b/fastapi_app.py
@@ -1,0 +1,99 @@
+import base64
+import io
+import os
+import numpy as np
+from PIL import Image
+from fastapi import FastAPI, File, UploadFile, Request
+from fastapi.responses import HTMLResponse
+from fastapi.templating import Jinja2Templates
+from tensorflow.keras.models import Sequential, load_model
+from tensorflow.keras.layers import Dense
+from tensorflow.keras.utils import to_categorical
+from sklearn.datasets import fetch_lfw_people
+from sklearn.model_selection import train_test_split
+
+app = FastAPI()
+templates = Jinja2Templates(directory="templates")
+
+MODEL_PATH = "model.h5"
+TARGET_NAMES = None
+IMG_H, IMG_W = 0, 0
+
+
+def train_model():
+    """Train the CNN model if weights are not available."""
+    global TARGET_NAMES, IMG_H, IMG_W
+    try:
+        faces = fetch_lfw_people(min_faces_per_person=100)
+    except Exception as exc:
+        raise RuntimeError("Unable to load LFW dataset. Ensure network access or pre-downloaded data.") from exc
+    TARGET_NAMES = faces.target_names
+    IMG_H, IMG_W = faces.images.shape[1:3]
+
+    mask = np.zeros(faces.target.shape, dtype=bool)
+    for target in np.unique(faces.target):
+        mask[np.where(faces.target == target)[0][:150]] = True
+
+    x = faces.data[mask] / 255.0
+    y = to_categorical(faces.target[mask])
+
+    x_train, x_test, y_train, y_test = train_test_split(
+        x, y, train_size=0.8, stratify=y, random_state=0
+    )
+
+    model = Sequential([
+        Dense(512, activation="relu", input_shape=(IMG_H * IMG_W,)),
+        Dense(len(TARGET_NAMES), activation="softmax"),
+    ])
+    model.compile(optimizer="adam", loss="categorical_crossentropy", metrics=["accuracy"])
+    model.fit(x_train, y_train, epochs=10, batch_size=20, validation_data=(x_test, y_test))
+    model.save(MODEL_PATH)
+    return model
+
+
+def load_or_train():
+    """Load existing model or train a new one."""
+    global TARGET_NAMES, IMG_H, IMG_W
+    if os.path.exists(MODEL_PATH):
+        model = load_model(MODEL_PATH)
+        # fetch dataset meta information for preprocessing
+        try:
+            faces = fetch_lfw_people(min_faces_per_person=100, download_if_missing=False)
+        except Exception as exc:
+            raise RuntimeError(
+                "Unable to load LFW dataset for preprocessing."
+            ) from exc
+        TARGET_NAMES = faces.target_names
+        IMG_H, IMG_W = faces.images.shape[1:3]
+    else:
+        model = train_model()
+    return model
+
+
+model = load_or_train()
+
+
+@app.get("/", response_class=HTMLResponse)
+async def index(request: Request):
+    return templates.TemplateResponse("index.html", {"request": request})
+
+
+@app.post("/predict", response_class=HTMLResponse)
+async def predict(request: Request, file: UploadFile = File(...)):
+    contents = await file.read()
+    image = Image.open(io.BytesIO(contents)).convert("L").resize((IMG_W, IMG_H))
+    arr = np.array(image).astype("float32") / 255.0
+    arr = arr.flatten().reshape(1, -1)
+    pred = model.predict(arr)
+    label = TARGET_NAMES[int(np.argmax(pred))]
+    encoded = base64.b64encode(contents).decode()
+    return templates.TemplateResponse(
+        "index.html",
+        {"request": request, "label": label, "image": encoded},
+    )
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Facial Recognition</title>
+    <style>
+        body { font-family: Arial, sans-serif; background-color: #f0f2f5; text-align: center; padding-top: 40px; }
+        .container { background-color: #fff; padding: 30px; border-radius: 8px; display: inline-block; box-shadow: 0 4px 6px rgba(0,0,0,0.1); }
+        h1 { margin-bottom: 20px; color: #333; }
+        .prediction { margin-top: 20px; font-size: 24px; color: #0077ff; }
+        img { max-width: 300px; margin-top: 20px; border-radius: 4px; }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>Facial Recognition Demo</h1>
+        <form action="/predict" method="post" enctype="multipart/form-data">
+            <input type="file" name="file" accept="image/*" required>
+            <br><br>
+            <button type="submit">Predict</button>
+        </form>
+        {% if label %}
+        <div class="prediction">Prediction: {{ label }}</div>
+        <img src="data:image/png;base64,{{ image }}" alt="Uploaded Image">
+        {% endif %}
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- introduce a simple FastAPI server for predictions
- add HTML template with basic styling
- document how to launch the web app in README

## Testing
- `git status --short`
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685052c1771c8329bbf29c0552bce90c